### PR TITLE
switching atob for btoa

### DIFF
--- a/couch.ts
+++ b/couch.ts
@@ -196,7 +196,10 @@ class CouchDatabase<T> {
     }>,
   ): Promise<(CouchDocument & T) | NotModified> {
     const res = await this._get("json", id, opts);
-    return res.json();
+    console.log('res', res);
+    const json = await res.json();
+    console.log('json', json);
+    return json;
   }
 
   async getMultipart(

--- a/couch.ts
+++ b/couch.ts
@@ -198,9 +198,9 @@ class CouchDatabase<T> {
             console.log('inside get')
     const res = await this._get("json", id, opts);
     console.log('res', res);
-    const json = await res.text();
-    console.log('json', json);
-    return json;
+    //const json = await res.text();
+    //console.log('json', json);
+    return {id: 'eded', rev: 'ededdd'};
   }
 
   async getMultipart(

--- a/couch.ts
+++ b/couch.ts
@@ -111,7 +111,6 @@ function makeFetch(
       const authorization = `Basic ${btoa(username + ":" + password)}`;
       headers.set("authorization", authorization);
     }
-    console.log('inside makefetch', `${endpoint}` + path)
     return fetch(`${endpoint}` + path, {
       headers,
       body,
@@ -195,10 +194,8 @@ class CouchDatabase<T> {
       revs_info: boolean;
     }>,
   ): Promise<(CouchDocument & T) | NotModified> {
-            console.log('inside get')
     const res = await this._get("json", id, opts);
-    console.log('res', res);
-    return {id: 'eded', rev: 'ededdd'};
+    return res.json();
   }
 
   async getMultipart(
@@ -217,7 +214,7 @@ class CouchDatabase<T> {
       revs: boolean;
       revs_info: boolean;
     }>,
-  ): Promise<String> {
+  ): Promise<Response> {
     return this._get("multipart", id, opts);
   }
 
@@ -238,10 +235,7 @@ class CouchDatabase<T> {
       revs: boolean;
       revs_info: boolean;
     }>,
-  ): Promise<String> {
-             return Promise.resolve( 'inside _Get')
-    //console.log('inside _Get')
-             /*
+  ): Promise<Response> {
     const params = new URLSearchParams();
     if (opts != null) {
       if (opts.attachments != null) {
@@ -254,17 +248,14 @@ class CouchDatabase<T> {
         );
       }
     }
-    console.log('inside _Get, before this fetch')
     const res = await this.fetch(`/${id}?${params.toString()}`, {
       method: "GET",
       headers: new Headers({ accept }),
     });
-console.log('res _get', res);
     if (res.status === 200 || res.status === 304) {
       return res;
     }
     throw new CouchError(res.status, await res.text());
-    */
   }
 
   async put(

--- a/couch.ts
+++ b/couch.ts
@@ -198,8 +198,6 @@ class CouchDatabase<T> {
             console.log('inside get')
     const res = await this._get("json", id, opts);
     console.log('res', res);
-    //const json = await res.text();
-    //console.log('json', json);
     return {id: 'eded', rev: 'ededdd'};
   }
 

--- a/couch.ts
+++ b/couch.ts
@@ -240,7 +240,7 @@ class CouchDatabase<T> {
       revs: boolean;
       revs_info: boolean;
     }>,
-  ): Promise<Response> {
+  ): Promise<String> {
              return Promise.resolve( 'inside _Get')
     //console.log('inside _Get')
              /*

--- a/couch.ts
+++ b/couch.ts
@@ -195,6 +195,7 @@ class CouchDatabase<T> {
       revs_info: boolean;
     }>,
   ): Promise<(CouchDocument & T) | NotModified> {
+            console.log('inside get')
     const res = await this._get("json", id, opts);
     console.log('res', res);
     const json = await res.json();

--- a/couch.ts
+++ b/couch.ts
@@ -223,7 +223,7 @@ class CouchDatabase<T> {
     return this._get("multipart", id, opts);
   }
 
-  async _get(
+  private async _get(
     accept: "json" | "multipart",
     id: string,
     opts?: Partial<{

--- a/couch.ts
+++ b/couch.ts
@@ -108,7 +108,7 @@ function makeFetch(
   ) => {
     if (opts.basicAuth) {
       const { username, password } = opts.basicAuth;
-      const authorization = `Basic ${atob(username + ":" + password)}`;
+      const authorization = `Basic ${btoa(username + ":" + password)}`;
       headers.set("authorization", authorization);
     }
     return fetch(`${endpoint}` + path, {

--- a/couch.ts
+++ b/couch.ts
@@ -241,7 +241,9 @@ class CouchDatabase<T> {
       revs_info: boolean;
     }>,
   ): Promise<Response> {
-    console.log('inside _Get')
+             return Promise.resolve({msg: 'inside _Get'})
+    //console.log('inside _Get')
+             /*
     const params = new URLSearchParams();
     if (opts != null) {
       if (opts.attachments != null) {
@@ -264,6 +266,7 @@ console.log('res _get', res);
       return res;
     }
     throw new CouchError(res.status, await res.text());
+    */
   }
 
   async put(

--- a/couch.ts
+++ b/couch.ts
@@ -223,7 +223,7 @@ class CouchDatabase<T> {
     return this._get("multipart", id, opts);
   }
 
-  private async _get(
+  async _get(
     accept: "json" | "multipart",
     id: string,
     opts?: Partial<{

--- a/couch.ts
+++ b/couch.ts
@@ -219,7 +219,7 @@ class CouchDatabase<T> {
       revs: boolean;
       revs_info: boolean;
     }>,
-  ): Promise<Response> {
+  ): Promise<String> {
     return this._get("multipart", id, opts);
   }
 

--- a/couch.ts
+++ b/couch.ts
@@ -241,7 +241,7 @@ class CouchDatabase<T> {
       revs_info: boolean;
     }>,
   ): Promise<Response> {
-             return Promise.resolve({msg: 'inside _Get'})
+             return Promise.resolve( 'inside _Get')
     //console.log('inside _Get')
              /*
     const params = new URLSearchParams();

--- a/couch.ts
+++ b/couch.ts
@@ -198,7 +198,7 @@ class CouchDatabase<T> {
             console.log('inside get')
     const res = await this._get("json", id, opts);
     console.log('res', res);
-    const json = await res.json();
+    const json = await res.text();
     console.log('json', json);
     return json;
   }

--- a/couch.ts
+++ b/couch.ts
@@ -111,6 +111,7 @@ function makeFetch(
       const authorization = `Basic ${btoa(username + ":" + password)}`;
       headers.set("authorization", authorization);
     }
+    console.log('inside makefetch', `${endpoint}` + path)
     return fetch(`${endpoint}` + path, {
       headers,
       body,

--- a/couch.ts
+++ b/couch.ts
@@ -241,6 +241,7 @@ class CouchDatabase<T> {
       revs_info: boolean;
     }>,
   ): Promise<Response> {
+    console.log('inside _Get')
     const params = new URLSearchParams();
     if (opts != null) {
       if (opts.attachments != null) {
@@ -253,6 +254,7 @@ class CouchDatabase<T> {
         );
       }
     }
+    console.log('inside _Get, before this fetch')
     const res = await this.fetch(`/${id}?${params.toString()}`, {
       method: "GET",
       headers: new Headers({ accept }),

--- a/couch.ts
+++ b/couch.ts
@@ -256,6 +256,7 @@ class CouchDatabase<T> {
       method: "GET",
       headers: new Headers({ accept }),
     });
+console.log('res _get', res);
     if (res.status === 200 || res.status === 304) {
       return res;
     }


### PR DESCRIPTION
Hello sir thanks for starting porting couchdb to deno
but I think there is a slight mistaking around adding credentials
it should be btoa instead of atob
the core atob function includes a regexp   if there is something different than 0-9 a-z
then the ":"  will return the following error

```
throw new DOMException(
      "The string to be decoded is not correctly encoded",
      "DataDecodeError"
    );
```
by the way i have already done that process client sided and its slightly different
```
const token = btoa(`${user}:${password}`, 'binary').toString('base64');
```
I have made a fork, made the change, import  my fork in my deno script and tested
and it works